### PR TITLE
Add Title back to ImportNode struct

### DIFF
--- a/claat/nodes/import.go
+++ b/claat/nodes/import.go
@@ -2,11 +2,12 @@ package nodes
 
 // NewImportNode creates a new Node of type NodeImport,
 // with initialized ImportNode.Content.
-func NewImportNode(url string) *ImportNode {
+func NewImportNode(url string, title string) *ImportNode {
 	return &ImportNode{
 		node:    node{typ: NodeImport},
 		Content: NewListNode(),
 		URL:     url,
+		Title:   title,
 	}
 }
 
@@ -14,6 +15,7 @@ func NewImportNode(url string) *ImportNode {
 type ImportNode struct {
 	node
 	URL     string
+	Title   string
 	Content *ListNode
 }
 


### PR DESCRIPTION
Not sure why it was removed from the `googlecodelabs/tools` repo but we need this change to compile `bin/claat`